### PR TITLE
fix: EX score for P2 on ScreenEvaluation

### DIFF
--- a/Themes/DDR A3/BGAnimations/ScreenEvaluation decorations/data/default.lua
+++ b/Themes/DDR A3/BGAnimations/ScreenEvaluation decorations/data/default.lua
@@ -13,7 +13,7 @@ local Fast=getenv("numFast"..ToEnumShortString(player));
 local Slow=getenv("numSlow"..ToEnumShortString(player));
 
 local Score = STATSMAN:GetCurStageStats():GetPlayerStageStats(player):GetScore();
-local EXScore = math.floor(STATSMAN:GetCurStageStats():GetPlayerStageStats(PLAYER_1):GetPossibleDancePoints())*(STATSMAN:GetCurStageStats():GetPlayerStageStats(PLAYER_1):GetPercentDancePoints())+0.5
+local EXScore = math.floor(STATSMAN:GetCurStageStats():GetPlayerStageStats(player):GetPossibleDancePoints())*(STATSMAN:GetCurStageStats():GetPlayerStageStats(player):GetPercentDancePoints())+0.5
 
 
 local Large = Def.BitmapText{


### PR DESCRIPTION
This PR does the following:
- Fixes an issue where player 2 EX score would display as `0` on the score evaluation screen if they were the only player.
- Fixes an issue where the player 2 EX score would display player 1's EX score on the score evaluation screen if both are playing.