### PR TITLE
Fix Dancing Stage loading on videos

### DIFF
--- a/Themes/DDR A3/BGAnimations/ScreenGameplay background/DanceStages/Characters.lua
+++ b/Themes/DDR A3/BGAnimations/ScreenGameplay background/DanceStages/Characters.lua
@@ -27,7 +27,7 @@ local function CharaAnimRate(self)
 	self:SetUpdateRate(spdRate)
 end
 
-local t = Def.ActorFrame{};
+local t = Def.ActorFrame{}
 
 ------- READ SELECTED CHARACTER -------
 local CharaRandom = GetAllCharacterNames()
@@ -36,7 +36,7 @@ table.remove(CharaRandom,IndexKey(CharaRandom,"None"))
 
 for pn in ivalues(GAMESTATE:GetEnabledPlayers()) do
     if GetUserPref("SelectCharacter"..pn) == "Random" then
-        WritePrefToFile("CharaRandom"..pn,CharaRandom[math.random(#CharaRandom)]);
+        WritePrefToFile("CharaRandom"..pn,CharaRandom[math.random(#CharaRandom)])
     end
 end
 
@@ -85,13 +85,16 @@ Listed = {
 
 ------- GENDER AND SIZE CHECK -------
 
-function CharacterInfoo(Chara,Read)
-	local CharaCfg = "/Characters/"..Chara.."/character.ini";
+local function CharacterInfoo(Chara,Read,default)
+	local CharaCfg = "/Characters/"..Chara.."/character.ini"
 	local Info = Config.Load(Read,CharaCfg)
+	if not Info then
+		return default
+	end
 	return Info
 end
 
-function NewChara(Chara)
+local function NewChara(Chara)
 	if CharacterInfoo("Size",Chara) ~= nil then
 		return true
 	else
@@ -103,8 +106,8 @@ Gender = {}
 Size = {}
 
 for i=1,#Listed do
-	Gender[i]=CharacterInfoo(Listed[i],"Genre")
-	Size[i]=CharacterInfoo(Listed[i],"Size")
+	Gender[i]=CharacterInfoo(Listed[i],"Genre","M")
+	Size[i]=CharacterInfoo(Listed[i],"Size",1)
 end
 
 ------- DANCEROUTINES-------
@@ -148,7 +151,7 @@ end
 
 for i=1,#Listed do
 
-	if tonumber(CharacterInfoo(Listed[i],"Size")) <= 0.5 then
+	if tonumber(CharacterInfoo(Listed[i],"Size",1)) <= 0.5 then
 		ShadowModel = "Model_Small.txt"
 	else
 		ShadowModel = "Model.txt"
@@ -171,7 +174,7 @@ for i=1,#Listed do
 						:x(PositionX[i]):z(PositionZ[i])
 						:position(Position)
 				end,
-		};
+		},
 		Def.Model {
 			Meshes="/Characters/DanceRepo/Shadow/"..ShadowModel,
 			Materials="/Characters/DanceRepo/Shadow/Model.txt",
@@ -182,9 +185,9 @@ for i=1,#Listed do
 						:x(PositionX[i]):z(PositionZ[i])
 						:position(Position)
 				end,
-		};
+		}
 	}
 
 end
 
-return t;
+return t

--- a/Themes/DDR A3/Graphics/Player judgment/default.lua
+++ b/Themes/DDR A3/Graphics/Player judgment/default.lua
@@ -212,8 +212,10 @@ t[#t+1] = Def.ActorFrame {
 		JudgeCmds[param.TapNoteScore](c.Judgment);
 		
 		c.ProtimingDisplay:visible( bShowProtiming );
-		c.ProtimingDisplay:settextf("%i",math.abs(fTapNoteOffset * 1000));
-		ProtimingCmds[param.TapNoteScore](c.ProtimingDisplay);
+		if bShowProtiming then
+			c.ProtimingDisplay:settextf("%.2f",math.abs(fTapNoteOffset * 1000));
+			ProtimingCmds[param.TapNoteScore](c.ProtimingDisplay);
+		end
 		
 		c.ProtimingAverage:visible( bShowProtiming );
 		c.ProtimingAverage:settextf("%.2f%%",clamp(100 - MakeAverage( tTotalJudgments ) * 1000 ,0,100));
@@ -247,7 +249,10 @@ t[#t+1] = Def.ActorFrame {
 			0,188)
 		);
 -- 		c.ProtimingGraphAverage:zoomtowidth( clamp(MakeAverage( tTotalJudgments ) * 1880,0,188) );
-		c.ProtimingGraphCenter:visible( bShowProtiming );
+		c.ProtimingGraphCenter:visible( bShowProtiming )
+		
+		if not bShowProtiming then return end
+
 		(cmd(sleep,2;linear,0.5;diffusealpha,0))(c.ProtimingGraphBG);
 		(cmd(sleep,2;linear,0.5;diffusealpha,0))(c.ProtimingGraphUnderlay);
 		(cmd(sleep,2;linear,0.5;diffusealpha,0))(c.ProtimingGraphWindowW3);


### PR DESCRIPTION
We had reports in the OutFox Discord server and on other sites that the Dancing Stage was still being loaded, despite a video being present. This was because of the loading process of the stages, which has been tweaked here to prevent such case.

I would still suggest reworking how these stages are made, because having Lua embedded to the stage to be loaded as global variables is quite sketchy.